### PR TITLE
Improve startup

### DIFF
--- a/scripts/zalenium.sh
+++ b/scripts/zalenium.sh
@@ -110,7 +110,7 @@ StartUp()
     if [ "${IN_TRAVIS}" = "true" ]; then
         sleep 20
     else
-        sleep 10
+        sleep 2
     fi
     echo "DockerSeleniumStarter node started!"
 

--- a/scripts/zalenium.sh
+++ b/scripts/zalenium.sh
@@ -24,6 +24,14 @@ EnsureCleanEnv()
     fi
 }
 
+EnsureDockerWorks()
+{
+    if ! docker images elgalu/selenium >/dev/null; then
+        echo "Docker seems to be not working properly, check the above error."
+        exit 1
+    fi
+}
+
 DockerTerminate()
 {
   echo "Trapped SIGTERM/SIGINT so shutting down Zalenium gracefully..."
@@ -37,6 +45,7 @@ trap DockerTerminate SIGTERM SIGINT SIGKILL
 
 StartUp()
 {
+    EnsureDockerWorks
     EnsureCleanEnv
 
     DOCKER_SELENIUM_IMAGE_COUNT=$(docker images | grep "elgalu/selenium" | wc -l)

--- a/src/main/java/de/zalando/tip/zalenium/proxy/DockerSeleniumStarterRemoteProxy.java
+++ b/src/main/java/de/zalando/tip/zalenium/proxy/DockerSeleniumStarterRemoteProxy.java
@@ -60,6 +60,7 @@ public class DockerSeleniumStarterRemoteProxy extends DefaultRemoteProxy impleme
     private static CommonProxyUtilities commonProxyUtilities = defaultCommonProxyUtilities;
 
     private static final String LOGGING_PREFIX = "[DS] ";
+    private static boolean setupCompleted;
 
     private static int chromeContainersOnStartup;
     private static int firefoxContainersOnStartup;
@@ -134,20 +135,42 @@ public class DockerSeleniumStarterRemoteProxy extends DefaultRemoteProxy impleme
 
     /*
         Starting a few containers (Firefox, Chrome), so they are ready when the tests come.
+        Executed in a thread so we don't wait for the containers to be created and the node
+        registration is not delayed.
     */
     @Override
     public void beforeRegistration() {
         readConfigurationFromEnvVariables();
-        if (getChromeContainersOnStartup() > 0 || getFirefoxContainersOnStartup() > 0) {
-            LOGGER.log(Level.INFO, LOGGING_PREFIX + "Setting up {0} Firefox nodes and {1} Chrome nodes ready to use.",
-                    new Object[]{getFirefoxContainersOnStartup(), getChromeContainersOnStartup()});
-            for (int i = 0; i < getChromeContainersOnStartup(); i++) {
-                startDockerSeleniumContainer(BrowserType.CHROME);
+        setupCompleted = false;
+        new Thread() {
+            public void run() {
+                String message = String.format("%s Setting up %s Firefox nodes and %s Chrome nodes...", LOGGING_PREFIX,
+                        getFirefoxContainersOnStartup(), getChromeContainersOnStartup());
+                LOGGER.log(Level.INFO, message);
+
+                int configuredContainers = getChromeContainersOnStartup() + getFirefoxContainersOnStartup();
+                int containersToCreate = configuredContainers > getMaxDockerSeleniumContainers() ?
+                        getMaxDockerSeleniumContainers() : configuredContainers;
+                int createdContainers = 0;
+
+                while (createdContainers < containersToCreate &&
+                        getNumberOfRunningContainers() <= getMaxDockerSeleniumContainers()) {
+
+                    boolean wasContainerCreated;
+                    if (createdContainers < getChromeContainersOnStartup()) {
+                        wasContainerCreated = startDockerSeleniumContainer(BrowserType.CHROME);
+                    } else {
+                        wasContainerCreated = startDockerSeleniumContainer(BrowserType.FIREFOX);
+                    }
+
+                    if (wasContainerCreated) {
+                        createdContainers++;
+                    }
+                }
+                LOGGER.log(Level.INFO, "Done setting up containers during startup.");
+                setupCompleted = true;
             }
-            for (int i = 0; i < getFirefoxContainersOnStartup(); i++) {
-                startDockerSeleniumContainer(BrowserType.FIREFOX);
-            }
-        }
+        }.start();
     }
 
     /*
@@ -216,7 +239,7 @@ public class DockerSeleniumStarterRemoteProxy extends DefaultRemoteProxy impleme
     }
 
     @VisibleForTesting
-    protected void startDockerSeleniumContainer(String browser) {
+    protected boolean startDockerSeleniumContainer(String browser) {
 
         if (validateAmountOfDockerSeleniumContainers()) {
 
@@ -273,10 +296,12 @@ public class DockerSeleniumStarterRemoteProxy extends DefaultRemoteProxy impleme
                 final ContainerCreation dockerSeleniumContainer = dockerClient.createContainer(containerConfig,
                         containerName);
                 dockerClient.startContainer(dockerSeleniumContainer.id());
+                return true;
             } catch (Exception e) {
                 LOGGER.log(Level.SEVERE, LOGGING_PREFIX + e.toString(), e);
             }
         }
+        return false;
     }
 
     private String getLatestDownloadedImage(String imageName) throws DockerException, InterruptedException {
@@ -369,6 +394,10 @@ public class DockerSeleniumStarterRemoteProxy extends DefaultRemoteProxy impleme
         DockerSeleniumStarterRemoteProxy.screenHeight = screenHeight <= 0 ? DEFAULT_SCREEN_HEIGHT : screenHeight;
     }
 
+    public boolean isSetupCompleted() {
+        return setupCompleted;
+    }
+
     @VisibleForTesting
     protected static void setEnv(final Environment env) {
         DockerSeleniumStarterRemoteProxy.env = env;
@@ -416,7 +445,7 @@ public class DockerSeleniumStarterRemoteProxy extends DefaultRemoteProxy impleme
         return dsCapabilities;
     }
 
-    private boolean validateAmountOfDockerSeleniumContainers() {
+    private int getNumberOfRunningContainers() {
         try {
             List<Container> containerList = dockerClient.listContainers(DockerClient.ListContainersParam.allContainers());
             int numberOfDockerSeleniumContainers = 0;
@@ -426,6 +455,16 @@ public class DockerSeleniumStarterRemoteProxy extends DefaultRemoteProxy impleme
                     numberOfDockerSeleniumContainers++;
                 }
             }
+            return numberOfDockerSeleniumContainers;
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, LOGGING_PREFIX + e.toString(), e);
+        }
+        return 0;
+    }
+
+    private boolean validateAmountOfDockerSeleniumContainers() {
+        try {
+            int numberOfDockerSeleniumContainers = getNumberOfRunningContainers();
 
             /*
                 Validation to avoid the situation where 20 containers are running and only 4 proxies are registered.
@@ -441,10 +480,11 @@ public class DockerSeleniumStarterRemoteProxy extends DefaultRemoteProxy impleme
                 return false;
             }
 
-            LOGGER.log(Level.FINE, LOGGING_PREFIX + "{0} docker-selenium containers running", containerList.size());
+            LOGGER.log(Level.FINE, String.format("%s %s docker-selenium containers running", LOGGING_PREFIX,
+                    numberOfDockerSeleniumContainers));
             if (numberOfDockerSeleniumContainers >= getMaxDockerSeleniumContainers()) {
-                LOGGER.log(Level.FINE, LOGGING_PREFIX + "Max. number of docker-selenium containers has been reached, no more " +
-                        "will be created until the number decreases below {0}.", getMaxDockerSeleniumContainers());
+                LOGGER.log(Level.FINE, LOGGING_PREFIX + "Max. number of docker-selenium containers has been reached, " +
+                        "no more will be created until the number decreases below {0}.", getMaxDockerSeleniumContainers());
                 return false;
             }
             return true;

--- a/src/main/java/de/zalando/tip/zalenium/proxy/SauceLabsRemoteProxy.java
+++ b/src/main/java/de/zalando/tip/zalenium/proxy/SauceLabsRemoteProxy.java
@@ -70,7 +70,7 @@ public class SauceLabsRemoteProxy extends DefaultRemoteProxy {
         for (JsonElement cap : slCapabilities.getAsJsonArray()) {
             JsonObject capAsJsonObject = cap.getAsJsonObject();
             DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
-            desiredCapabilities.setCapability(RegistrationRequest.MAX_INSTANCES, 10);
+            desiredCapabilities.setCapability(RegistrationRequest.MAX_INSTANCES, 1);
             desiredCapabilities.setBrowserName(capAsJsonObject.get("api_name").getAsString());
             desiredCapabilities.setPlatform(getPlatform(capAsJsonObject.get("os").getAsString()));
             desiredCapabilities.setVersion(capAsJsonObject.get("long_version").getAsString());

--- a/src/test/java/de/zalando/tip/zalenium/proxy/DockerSeleniumRemoteProxyTest.java
+++ b/src/test/java/de/zalando/tip/zalenium/proxy/DockerSeleniumRemoteProxyTest.java
@@ -188,6 +188,9 @@ public class DockerSeleniumRemoteProxyTest {
                     DockerSeleniumStarterRemoteProxy.class.getCanonicalName());
             DockerSeleniumStarterRemoteProxy dsProxy = new DockerSeleniumStarterRemoteProxy(request, registry);
             DockerSeleniumStarterRemoteProxy.setMaxDockerSeleniumContainers(1);
+            DockerSeleniumStarterRemoteProxy.setScreenHeight(DockerSeleniumStarterRemoteProxy.DEFAULT_SCREEN_HEIGHT);
+            DockerSeleniumStarterRemoteProxy.setScreenWidth(DockerSeleniumStarterRemoteProxy.DEFAULT_SCREEN_WIDTH);
+            DockerSeleniumStarterRemoteProxy.setTimeZone(DockerSeleniumStarterRemoteProxy.DEFAULT_TZ);
             dsProxy.getNewSession(getCapabilitySupportedByDockerSelenium());
 
             // Creating a spy proxy to verify the invoked methods
@@ -243,6 +246,9 @@ public class DockerSeleniumRemoteProxyTest {
                     DockerSeleniumStarterRemoteProxy.class.getCanonicalName());
             DockerSeleniumStarterRemoteProxy dsProxy = new DockerSeleniumStarterRemoteProxy(request, registry);
             DockerSeleniumStarterRemoteProxy.setMaxDockerSeleniumContainers(1);
+            DockerSeleniumStarterRemoteProxy.setScreenHeight(DockerSeleniumStarterRemoteProxy.DEFAULT_SCREEN_HEIGHT);
+            DockerSeleniumStarterRemoteProxy.setScreenWidth(DockerSeleniumStarterRemoteProxy.DEFAULT_SCREEN_WIDTH);
+            DockerSeleniumStarterRemoteProxy.setTimeZone(DockerSeleniumStarterRemoteProxy.DEFAULT_TZ);
             dsProxy.getNewSession(getCapabilitySupportedByDockerSelenium());
 
             // Mocking the environment variable to return false for video recording enabled

--- a/src/test/java/de/zalando/tip/zalenium/proxy/DockerSeleniumStarterRemoteProxyTest.java
+++ b/src/test/java/de/zalando/tip/zalenium/proxy/DockerSeleniumStarterRemoteProxyTest.java
@@ -130,6 +130,17 @@ public class DockerSeleniumStarterRemoteProxyTest {
         verify(spyProxy, times(1)).startDockerSeleniumContainer(BrowserType.FIREFOX);
     }
 
+    @Test
+    public void noContainerIsStartedWhenBrowserCapabilityIsAbsent() {
+        // Browser is absent
+        Map<String, Object> nonSupportedCapability = new HashMap<>();
+        nonSupportedCapability.put(CapabilityType.PLATFORM, Platform.WINDOWS);
+        TestSession testSession = spyProxy.getNewSession(nonSupportedCapability);
+
+        Assert.assertNull(testSession);
+        verify(spyProxy, never()).startDockerSeleniumContainer(anyString());
+    }
+
     /*
         The following tests check that if for any reason the capabilities from DockerSelenium cannot be
         fetched, it should fallback to the default ones.

--- a/src/test/java/de/zalando/tip/zalenium/proxy/DockerSeleniumStarterRemoteProxyTest.java
+++ b/src/test/java/de/zalando/tip/zalenium/proxy/DockerSeleniumStarterRemoteProxyTest.java
@@ -22,7 +22,11 @@ import org.openqa.selenium.remote.CapabilityType;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.verify;
@@ -32,6 +36,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.withSettings;
+import static org.awaitility.Awaitility.await;
 
 
 public class DockerSeleniumStarterRemoteProxyTest {
@@ -286,6 +291,8 @@ public class DockerSeleniumStarterRemoteProxyTest {
 
         registry.add(spyProxy);
 
+        Callable<Boolean> callable = () -> spyProxy.isSetupCompleted();
+        await().atMost(1, SECONDS).pollInterval(100, MILLISECONDS).until(callable);
         verify(spyProxy, times(amountOfChromeContainers)).startDockerSeleniumContainer(BrowserType.CHROME);
         verify(spyProxy, times(amountOfFirefoxContainers)).startDockerSeleniumContainer(BrowserType.FIREFOX);
         Assert.assertEquals(amountOfChromeContainers, DockerSeleniumStarterRemoteProxy.getChromeContainersOnStartup());

--- a/src/test/java/de/zalando/tip/zalenium/proxy/DockerSeleniumStarterRemoteProxyTest.java
+++ b/src/test/java/de/zalando/tip/zalenium/proxy/DockerSeleniumStarterRemoteProxyTest.java
@@ -134,7 +134,7 @@ public class DockerSeleniumStarterRemoteProxyTest {
     public void noContainerIsStartedWhenBrowserCapabilityIsAbsent() {
         // Browser is absent
         Map<String, Object> nonSupportedCapability = new HashMap<>();
-        nonSupportedCapability.put(CapabilityType.PLATFORM, Platform.WINDOWS);
+        nonSupportedCapability.put(CapabilityType.PLATFORM, Platform.LINUX);
         TestSession testSession = spyProxy.getNewSession(nonSupportedCapability);
 
         Assert.assertNull(testSession);


### PR DESCRIPTION
When starting up, you can configure the number of Chrome and Firefox nodes that will be available right away before the tests start. Currently this is not being handled properly because:
* This runs in the `beforeRegister` and if too many nodes are configured, then the registration will take too long, giving this the chance that the SauceLabs node registers first and processes some tests that docker-selenium should process.
* There is a validation to avoid having many nodes trying to register at the same time (which basically kills the hub). And thanks to this validation, sometimes the number of nodes created on startup is not the configured one, it is just that no one has noticed!