### PR TITLE
Allow to mount the docker binary + active wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,20 @@ Zalenium uses docker to scale on-demand, therefore we need to give it the `docke
 * To see the recorded videos, check the `/tmp/videos` folder (or the folder that you mapped when starting the container).
 
 ### Docker version
-Zalenium is currently compatible with Docker `1.11` and `1.12` __default__, is recommended that you explicitly tell Zalenium which major version you are using via `-e DOCKER=1.11` due to API compatibility issues. In the future this will be automated on our side.
+
+#### Linux
+For Linux systems you can simply share the docker binary via `-v $(which docker):/usr/bin/docker`
+
+```sh
+docker run --rm -ti --name zalenium -p 4444:4444 -p 5555:5555 \
+  -v $(which docker):/usr/bin/docker \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /tmp/videos:/home/seluser/videos \
+  dosel/zalenium start --sauceLabsEnabled false
+```
+
+#### OSX
+Zalenium for OSX is currently compatible with Docker `1.11` and `1.12` __default__. In Mac is recommended that you explicitly tell Zalenium which major version you are using via `-e DOCKER=1.11` due to API compatibility issues. In the future this will be automated on our side as it is with Linux (read above)
 
 ```sh
 docker run --rm -ti --name zalenium -p 4444:4444 -p 5555:5555 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -204,7 +204,7 @@ RUN set -x \
           -o docker.tgz \
   && echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
   && tar -xzvf docker.tgz \
-  && mv docker/docker /usr/local/bin/docker-${DOCKER_VERSION} \
+  && mv docker/docker /usr/bin/docker-${DOCKER_VERSION} \
   && rm -rf docker/ && rm docker.tgz \
   && docker-${DOCKER_VERSION} --version | grep "${DOCKER_VERSION}"
 
@@ -219,7 +219,7 @@ RUN set -x \
           -o docker.tgz \
   && echo "${DOCKER_SHA256} *docker.tgz" | sha256sum -c - \
   && tar -xzvf docker.tgz \
-  && mv docker/docker /usr/local/bin/docker-${DOCKER_VERSION} \
+  && mv docker/docker /usr/bin/docker-${DOCKER_VERSION} \
   && rm -rf docker/ && rm docker.tgz \
   && docker-${DOCKER_VERSION} --version | grep "${DOCKER_VERSION}"
 

--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -3,10 +3,16 @@
 # set -e: exit asap if a command exits with a non-zero status
 set -e
 
-# Grab the complete docker version `1.12.3` out of the partial one `1.12`
-export DOCKER_VERSION=$(ls /usr/local/bin/docker-${DOCKER}* | grep -Po '(?<=docker-)([a-z0-9\.]+)' | head -1)
-# Link the docker binary to the selected docker version via e.g. `-e DOCKER=1.11`
-sudo ln -s /usr/local/bin/docker-${DOCKER_VERSION} /usr/local/bin/docker
+# /usr/bin/docker exists when docker run has
+#   -v $(which docker):/usr/bin/docker
+if [ -f /usr/bin/docker ]; then
+    echo "Docker binary already present, will use that one."
+else
+    # Grab the complete docker version `1.12.3` out of the partial one `1.12`
+    export DOCKER_VERSION=$(ls /usr/bin/docker-${DOCKER}* | grep -Po '(?<=docker-)([a-z0-9\.]+)' | head -1)
+    # Link the docker binary to the selected docker version via e.g. `-e DOCKER=1.11`
+    sudo ln -s /usr/bin/docker-${DOCKER_VERSION} /usr/bin/docker
+fi
 
 # Make sure Docker works before continuing
 docker --version

--- a/scripts/zalenium.sh
+++ b/scripts/zalenium.sh
@@ -15,6 +15,48 @@ PID_PATH_SELENIUM=/tmp/selenium-pid
 PID_PATH_DOCKER_SELENIUM_NODE=/tmp/docker-selenium-node-pid
 PID_PATH_SAUCE_LABS_NODE=/tmp/sauce-labs-node-pid
 
+WaitSeleniumHub()
+{
+    # Other option is to wait for certain text at
+    #  logs/stdout.zalenium.hub.log
+    while ! curl -sSL "http://localhost:4444/wd/hub/status" 2>&1 \
+            | jq -r '.status' 2>&1 | grep "13" >/dev/null; do
+        echo -n '.'
+        sleep 0.2
+    done
+}
+export -f WaitSeleniumHub
+
+WaitStarterProxy()
+{
+    # Other option is to wait for certain text at
+    #  logs/stdout.zalenium.docker.node.log
+    while ! curl -sSL "http://localhost:30000/wd/hub/status" 2>&1 \
+            | jq -r '.state' 2>&1 | grep "success" >/dev/null; do
+        echo -n '.'
+        sleep 0.2
+    done
+}
+export -f WaitStarterProxy
+
+WaitSauceLabsProxy()
+{
+    # Wait for the sauce node success
+    while ! curl -sSL "http://localhost:30001/wd/hub/status" 2>&1 \
+            | jq -r '.state' 2>&1 | grep "success" >/dev/null; do
+        echo -n '.'
+        sleep 0.2
+    done
+
+    # Also wait for the sauce url though this is optional
+    DONE_MSG="ondemand.saucelabs.com"
+    while ! docker logs zalenium | grep "${DONE_MSG}" >/dev/null; do
+        echo -n '.'
+        sleep 0.2
+    done
+}
+export -f WaitSauceLabsProxy
+
 EnsureCleanEnv()
 {
     CONTAINERS=$(docker ps -a -f name=zalenium_ -q | wc -l)
@@ -109,11 +151,10 @@ StartUp()
     -role hub -throwOnCapabilityNotPresent true > logs/stdout.zalenium.hub.log &
     echo $! > ${PID_PATH_SELENIUM}
 
-    IN_TRAVIS="${CI:=false}"
-    if [ "${IN_TRAVIS}" = "true" ]; then
-        sleep 20
-    else
-        sleep 1
+    if ! timeout --foreground "1m" bash -c WaitSeleniumHub; then
+        echo "GridLauncher failed to start after 1 minute, failing..."
+        curl "http://localhost:4444/wd/hub/status"
+        exit 11
     fi
     echo "Selenium Hub started!"
 
@@ -124,22 +165,18 @@ StartUp()
      -port 30000 > logs/stdout.zalenium.docker.node.log &
     echo $! > ${PID_PATH_DOCKER_SELENIUM_NODE}
 
-    if [ "${IN_TRAVIS}" = "true" ]; then
-        sleep 20
-    else
-        # TODO: Replace sleep with active wait on the grid
-        #       and the # nodes required at start time (e.g. 2)
-        # https://github.com/SeleniumHQ/docker-selenium/issues/332#issuecomment-259423033
-        sleep 2
+    if ! timeout --foreground "30s" bash -c WaitStarterProxy; then
+        echo "StarterRemoteProxy failed to start after 30 seconds, failing..."
+        exit 12
     fi
     echo "DockerSeleniumStarter node started!"
 
-    if ! curl -sSL http://localhost:4444 | grep Grid >/dev/null; then
+    if ! curl -sSL "http://localhost:4444" | grep Grid >/dev/null; then
         echo "Error: The Grid is not listening at port 4444"
         exit 7
     fi
 
-    if ! curl -sSL http://localhost:5555/proxy/4444/ | grep Grid >/dev/null; then
+    if ! curl -sSL "http://localhost:5555/proxy/4444/" | grep Grid >/dev/null; then
         echo "Error: Nginx is not redirecting to the grid"
         exit 8
     fi
@@ -151,15 +188,16 @@ StartUp()
          -port 30001 > logs/stdout.zalenium.sauce.node.log &
         echo $! > ${PID_PATH_SAUCE_LABS_NODE}
 
-        if [ "${IN_TRAVIS}" = "true" ]; then
-            sleep 20
-        else
-            sleep 2
+        if ! timeout --foreground "40s" bash -c WaitSauceLabsProxy; then
+            echo "SauceLabsRemoteProxy failed to start after 40 seconds, failing..."
+            exit 12
         fi
         echo "Sauce Labs node started!"
     else
         echo "Sauce Labs not enabled..."
     fi
+
+    echo "Zalenium is now ready!"
 
     # When running in docker do not exit this script
     wait


### PR DESCRIPTION
- Allows to mount the docker binary (see README changes)
- Performs active wait, i.e. removed `sleep 2` and `sleep 20`